### PR TITLE
Fix str-replace when $substr is at the beginning of $string

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,8 +12,7 @@ module.exports = function (grunt) {
 
     sass: {
       options: {
-        unixNewlines: true,
-        sourcemap: 'none'
+        unixNewlines: true
       },
 
       main: {

--- a/string/_str-replace.scss
+++ b/string/_str-replace.scss
@@ -11,7 +11,9 @@
 
   @while ($position-found and $position-found > 0) {
     $length-substr: str-length($substr);
-    $processed: append($processed, str-slice($string, 0, $position-found - 1));
+    @if (1 != $position-found) {
+      $processed: append($processed, str-slice($string, 0, $position-found - 1));
+    }
     $processed: append($processed, $newsubstr);
     $string: str-slice($string, $position-found + $length-substr);
 

--- a/test/expected/color.css
+++ b/test/expected/color.css
@@ -5,7 +5,7 @@
   color: #cccccc; }
 
 .encode-color-hex {
-  content: "%23fc0"; }
+  content: "%23ffcc00"; }
 
 .encode-color-func {
   content: "rgba(255%2C255%2C255%2C0.5)"; }

--- a/test/expected/string.css
+++ b/test/expected/string.css
@@ -3,3 +3,6 @@
 
 .str-replace-once {
   content: "lprem ipsum dolor sit amet"; }
+
+.str-replace-once {
+  content: "Lorem ipsum dolor sit amet"; }

--- a/test/fixtures/string.scss
+++ b/test/fixtures/string.scss
@@ -7,3 +7,7 @@
 .str-replace-once {
   content: "#{str-replace('lorem ipsum dolor sit amet', 'o', 'p', 0)}";
 }
+
+.str-replace-once {
+  content: "#{str-replace('lorem ipsum dolor sit amet', 'l', 'L')}";
+}


### PR DESCRIPTION
e.g. `str-replace('abc', 'a', 'A')` returned `'aAbc'`, because `str-slice($string, 0, 0)` returns first letter and it has been appended to `$processed`.

btw. sass strings are indexed from 1: http://sass-lang.com/documentation/Sass/Script/Functions.html#str_slice-instance_method